### PR TITLE
Add error403 parameter to handle 403 errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ This component takes the following inputs.
 - targetDomain (string) - the domain used to serve the content. A Route53 hosted zone must exist for this domain is this option is specified
 - index.html (string) - the default document for the site. Defaults to index.html
 - error404 (string) - the default 404 error page
+- error403 (string) - the default 403 error page
 - certificateARN (string) - the ARN of the ACM certificate to use for serving HTTPS. If one is not provided, a certificate will be created during the provisioning process
 - cacheTTL (number) - TTL in seconds for cached objects
 - withLogs (boolean) - provision a bucket to house access logs

--- a/provider/cmd/pulumi-resource-aws-static-website/website.ts
+++ b/provider/cmd/pulumi-resource-aws-static-website/website.ts
@@ -31,6 +31,7 @@ export interface WebsiteArgs {
     sitePath: string;
     indexHTML: string;
     error404: string;
+    error403?: string;
     withCDN: boolean;
     cdnArgs?: CdnArgs;
     priceClass: string;
@@ -86,6 +87,11 @@ export class Website extends pulumi.ComponentResource {
         // Check the error document exists if specified.
         if (args.error404 && !fs.existsSync(path.join(args.sitePath, args.error404))) {
             pulumi.log.warn(`Default document "${args.error404}" does not exist.`);
+        }
+
+        // Check the error document exists if specified.
+        if (args.error403 && !fs.existsSync(path.join(args.sitePath, args.error403))) {
+            pulumi.log.warn(`Default document "${args.error403}" does not exist.`);
         }
 
         // Get the current stack and check the outputs.
@@ -532,7 +538,8 @@ export class Website extends pulumi.ComponentResource {
             // You can customize error responses. When CloudFront receives an error from the origin (e.g. S3 or some other
             // web service) it can return a different error code, and return the response for a different resource.
             customErrorResponses: [
-                { errorCode: 404, responseCode: 404, responsePagePath: `/${this.args.error404}` }
+                { errorCode: 404, responseCode: 404, responsePagePath: `/${this.args.error404}` },
+                { errorCode: 403, responseCode: 403, responsePagePath: `/${this.args.error403}` }
             ],
 
             restrictions: {

--- a/schema.json
+++ b/schema.json
@@ -104,6 +104,10 @@
                     "type": "string",
                     "description": "default 404 page"
                 },
+                "error403": {
+                    "type": "string",
+                    "description": "default 403 page"
+                },
                 "certificateARN": {
                     "type": "string",
                     "description": "The ARN of the ACM certificate to use for serving HTTPS. If one is not provided, a certificate will be created during the provisioning process."


### PR DESCRIPTION
Add the ability to redirect 403 errors on websites.

* **provider/cmd/pulumi-resource-aws-static-website/website.ts**
  - Add `error403` parameter to `WebsiteArgs` interface.
  - Add check for existence of `error403` document.
  - Update `customErrorResponses` property in CloudFront distribution configuration to include 403 error configuration.

* **README.md**
  - Update documentation to include the new `error403` parameter.

* **schema.json**
  - Add `error403` parameter to `WebsiteArgs` type definition.